### PR TITLE
ttc-connectors-processing to 1.0.2

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -16,3 +16,6 @@ dependencies:
 - name: ttc-connectors-ranking
   repository: http://jenkins-x-chartmuseum:8080
   version: 1.0.4
+- name: ttc-connectors-processing
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 1.0.2


### PR DESCRIPTION
Promote ttc-connectors-processing to version 1.0.2