### PR TITLE
ttc-connectors-dummytwitter to 1.0.6

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -19,3 +19,6 @@ dependencies:
 - name: ttc-connectors-processing
   repository: http://jenkins-x-chartmuseum:8080
   version: 1.0.2
+- name: ttc-connectors-dummytwitter
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 1.0.6


### PR DESCRIPTION
Promote ttc-connectors-dummytwitter to version 1.0.6