### PR TITLE
ttc-connectors-reward to 1.0.4

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -12,7 +12,7 @@ dependencies:
   version: 1.0.16
 - name: ttc-connectors-reward
   repository: http://jenkins-x-chartmuseum:8080
-  version: 1.0.3
+  version: 1.0.4
 - name: ttc-connectors-ranking
   repository: http://jenkins-x-chartmuseum:8080
   version: 1.0.4


### PR DESCRIPTION
Promote ttc-connectors-reward to version 1.0.4