### PR TITLE
ttc-connectors-dummytwitter to 1.0.9

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -21,7 +21,7 @@ dependencies:
   version: 1.0.3
 - name: ttc-connectors-dummytwitter
   repository: http://jenkins-x-chartmuseum:8080
-  version: 1.0.8
+  version: 1.0.9
 - name: rabbitmq
   repository: https://kubernetes-charts.storage.googleapis.com
   version: 0.8.0


### PR DESCRIPTION
Promote ttc-connectors-dummytwitter to version 1.0.9