### PR TITLE
ttc-connectors-processing to 1.0.5

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -18,7 +18,7 @@ dependencies:
   version: 1.0.5
 - name: ttc-connectors-processing
   repository: http://jenkins-x-chartmuseum:8080
-  version: 1.0.3
+  version: 1.0.5
 - name: ttc-connectors-dummytwitter
   repository: http://jenkins-x-chartmuseum:8080
   version: 1.0.8


### PR DESCRIPTION
Promote ttc-connectors-processing to version 1.0.5